### PR TITLE
Wrapping layout-on-load directive in debounce

### DIFF
--- a/src/layout-on-load.directive.js
+++ b/src/layout-on-load.directive.js
@@ -14,7 +14,10 @@
       restrict: 'A',
       link: function(scope, element) {
         element.bind('load error', function() {
-          $rootScope.$broadcast('dynamicLayout.layout');
+          $timeout.cancel(timeoutId);
+          timeoutId = $timeout(function() {
+            $rootScope.$broadcast('dynamicLayout.layout');
+          });
         });
       }
     };


### PR DESCRIPTION
Wrapped the layout-on-load directive work with large sets of images. We've got a few hundred images which we're using this on, it pretty much calls layout() for each and dies. It also seems to fix issues with them not always correctly calculating.