### PR TITLE
Wrong calculation in positionService#setItemsColumnSpan

### DIFF
--- a/src/position.service.js
+++ b/src/position.service.js
@@ -305,7 +305,7 @@
     function setItemsColumnSpan(colSize) {
       var i;
       for (i = 0; i < items.length; ++i) {
-        items[i].columnSpan = Math.ceil(items[i].width / colSize);
+        items[i].columnSpan = Math.ceil(items[i].width.toFixed(2) / colSize.toFixed(2));
       }
     }
 


### PR DESCRIPTION
items[i].width isn't absolutely safe, the return value has sometimes multiple decimal places, which leads to a wrong calculation of the actual columnSpan because Math.ceil will always return the smallest integer greater than or equal to a given number. Using this limitation seems to work great!